### PR TITLE
Update copilot init command in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This is a sample AWS Copilot sample app. You can use AWS Copilot to deploy this 
 To deploy this app, clone this repo and then run:
 
 ```
-copilot init --app demo                  \
-  --svc api                              \
-  --svc-type 'Load Balanced Web Service' \
-  --dockerfile './Dockerfile'            \ 
+copilot init --app demo \
+  --name api \
+  --type "Load Balanced Web Service" \
+  --dockerfile "./Dockerfile" \
   --deploy
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

The copilot init command has changed some flags : https://aws.github.io/copilot-cli/docs/commands/init/ .
From my testing, the existing copilot init command will cause error :
```
copilot init  --app demo \
  --svc front-end \
  --svc-type 'Load Balanced Web Service' \
  --dockerfile './Dockerfile' \
  --deploy
✘ unknown flag: --svc
```

It should changed to the following : 
```
copilot init --app demo \
  --name api \
  --type "Load Balanced Web Service" \
  --dockerfile "./Dockerfile" \
  --deploy
```

*Description of changes:*

Update the init command 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
